### PR TITLE
Checkmark in a menu item will still be visible after hovering mouse over an item

### DIFF
--- a/source/DefaultControls/Menu.xaml
+++ b/source/DefaultControls/Menu.xaml
@@ -185,7 +185,8 @@
                                   MaxHeight="16" MaxWidth="16"
                                   VerticalAlignment="Center" ContentSource="Icon" />
                 <Grid x:Name="GlyphPanel" Grid.Column="0" Visibility="Collapsed" Margin="5,0,-5,0" VerticalAlignment="Center">
-                    <TextBlock FontFamily="Marlett" Text="a" VerticalAlignment="Center" Style="{DynamicResource BaseTextBlockStyle}" />
+                    <TextBlock FontFamily="Marlett" Text="a" VerticalAlignment="Center" Style="{DynamicResource BaseTextBlockStyle}"
+                               Foreground="{TemplateBinding Foreground}"/>
                 </Grid>
                 <TextBlock VerticalAlignment="Center" Grid.Column="1" Margin="5,0,5,0" Padding="5" Style="{DynamicResource BaseTextBlockStyle}"
                            Foreground="{TemplateBinding Foreground}">


### PR DESCRIPTION
This is a screenshot with this fix in place. The checkmark is now visible even when mouse is hovered over the menu item because the checkmark color gets inverted just like the text does so that it is black on white instead of white on white.

This is how it looks in Helium right now:
<img width="147" alt="image" src="https://github.com/darklinkpower/Helium/assets/6503344/ed4dfdcb-68e2-46cf-b7e0-bba357a2b4dc">

This is how it looks with my change:
<img width="133" alt="image" src="https://github.com/darklinkpower/Helium/assets/6503344/5267453f-caa1-4ebb-95d5-11e6cdf25f27">

Ignore the fact that my screenshot shows the menu item highlighting taking the full width of the menu item. That is simply because I have forked Helium and made some other style changes. But I thought the change in this PR about making sure the checkmark is visible might be something you would want to take because it feels like a bug and less so a subjective styling choice.